### PR TITLE
Rename facades, providers dirs to fix PSR-4 compatibility

### DIFF
--- a/src/Facades/PDFMergerFacade.php
+++ b/src/Facades/PDFMergerFacade.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GrofGraf\LaravelPDFMerger\Facades;
+namespace JorrenH\LaravelPDFMerger\Facades;
 
 use \Illuminate\Support\Facades\Facade;
 

--- a/src/Providers/PDFMergerServiceProvider.php
+++ b/src/Providers/PDFMergerServiceProvider.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace GrofGraf\LaravelPDFMerger\Providers;
+namespace JorrenH\LaravelPDFMerger\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use GrofGraf\LaravelPDFMerger\PDFMerger;
+use JorrenH\LaravelPDFMerger\PDFMerger;
 
 class PDFMergerServiceProvider extends ServiceProvider
 {
@@ -14,7 +14,9 @@ class PDFMergerServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        $this->publishes([
+            __DIR__.'/../../config/pdfmerger.php' => config_path('pdfmerger.php'),
+        ]);
     }
 
     /**
@@ -25,8 +27,7 @@ class PDFMergerServiceProvider extends ServiceProvider
     public function register()
     {
       $this->app->singleton('PDFMerger', function ($app) {
-          $pdfMerger = new PDFMerger($app['files']);
-          return $pdfMerger;
+          return new PDFMerger($app['files']);
       });
     }
 }


### PR DESCRIPTION
The namespaces of PDFMergerFacade and PDFMergerServiceProvider did not
match their respective file paths, thus they did not comply with PSR-4
autoloading standards. This causes autoloading to fail in Composer 2.
Rather than change the namespace, which would break backwards
compatibility, the directories have been renamed.